### PR TITLE
Add simulação faltas simétricas trifásicas

### DIFF
--- a/src/maths/power_flow.py
+++ b/src/maths/power_flow.py
@@ -201,6 +201,40 @@ class PowerFlow:
     def print_state(self):
         for bus in self.buses.values():
             print(f"Bus: {bus.name}, V: {bus.v}, O: {bus.o}, P: {bus.p}, Q: {bus.q}")
+            
+
+    # --------------------------------------------------------------------
+    # Adição do código para cálculo de faltas
+
+    def get_ybus_numpy(self) -> numpy.ndarray:
+        """
+        Devolve a matriz Ybus interna como um numpy.ndarray de complexos.
+        Deve ser chamada DEPOIS de solve(), pois usa self.__yMatrix.
+        """
+        # self.__yMatrix.y_matrix é uma lista de listas de complexos
+        return numpy.array(self.__yMatrix.y_matrix, dtype=complex)
+
+    def get_bus_index_dict(self) -> dict[str, int]:
+        """
+        Devolve um dicionário {bus_id: indice_na_matriz}.
+        """
+        return {bus.id: bus.index for bus in self.buses.values()}
+
+    def get_bus_voltages_complex_pu(self) -> dict[str, complex]:
+        """
+        Devolve um dicionário {bus_id: V_complex_pu} com a tensão pré-falta.
+
+        Usa V = |V| * e^{j·theta}, onde:
+          - bus.v é o módulo em pu
+          - bus.o é o ângulo em radianos
+        """
+        return {
+            bus.id: bus.v * cmath.exp(1j * bus.o)
+            for bus in self.buses.values()
+        }
+
+    # --------------------------------------------------------------------
+
 
     def transposeList(self, list: list[float]) -> list[list[float]]:
         return [[list[j]] for j in range(len(list))]

--- a/src/maths/short_circuit.py
+++ b/src/maths/short_circuit.py
@@ -1,0 +1,151 @@
+from dataclasses import dataclass
+from typing import Dict
+import numpy as np
+from models.faults import FaultSpec, FaultType, FaultResultBasic, FaultStudyResult
+
+@dataclass
+class ThreePhaseFaultResult:
+    """Resultado básico de uma falta trifásica em uma barra."""
+    fault_bus_id: str
+    I_fault: complex                   # corrente de falta na barra em pu
+    V_post: Dict[str, complex]         # tensões pós-falta em cada barra (pu)
+
+
+class ShortCircuitSolver:
+    """
+    Resolve falta trifásica (simétrica) usando apenas a rede de sequência positiva.
+    """
+
+    def __init__(self, ybus: np.ndarray, pre_fault_voltages: Dict[str, complex], bus_index: Dict[str, int]):
+        """
+        :param ybus: matriz Ybus (sequência positiva), NxN, como numpy.array de complexos
+        :param pre_fault_voltages: tensões pré-falta em pu, ex: {"B1": 1+0j, "B2": 0.98-0.02j, ...}
+        :param bus_index: mapeia id da barra -> índice da matriz, ex: {"B1": 0, "B2": 1, ...}
+        """
+        self.ybus = ybus
+        self.pre_v = pre_fault_voltages
+        self.bus_index = bus_index
+
+        # Calcula Zbus = Ybus^(-1)
+        self.zbus = np.linalg.inv(self.ybus)
+
+    def three_phase_fault(self, spec: FaultSpec) -> FaultStudyResult:
+        """
+        Calcula falta trifásica (simétrica) em uma barra.
+
+        Usa apenas a rede de sequência positiva.
+        """
+        if spec.fault_type != FaultType.THREE_PHASE:
+            raise ValueError("three_phase_fault só aceita FaultType.THREE_PHASE")
+
+        fault_bus_id = spec.bus_id
+        z_fault_pu = spec.z_fault_pu
+
+        # índice da barra de falta na matriz
+        k = self.bus_index[fault_bus_id]
+
+        # tensão pré-falta na barra de falta (seq. positiva)
+        V_pref = self.pre_v[fault_bus_id]
+
+        # impedância de Thevenin vista da barra de falta
+        Z_th = self.zbus[k, k]
+
+        # corrente de falta na barra em falta (seq. positiva)
+        I_fault = V_pref / (Z_th + z_fault_pu)
+
+        # resultado por barra
+        results: Dict[str, FaultResultBasic] = {}
+
+        for bus_id, i in self.bus_index.items():
+            Zik = self.zbus[i, k]
+            V_post = self.pre_v[bus_id] - Zik * I_fault
+
+            # por enquanto, corrente não nula só na barra em falta
+            I_bus = I_fault if bus_id == fault_bus_id else 0+0j
+
+            results[bus_id] = FaultResultBasic(
+                bus_id=bus_id,
+                v_pu=V_post,
+                i_pu=I_bus,
+            )
+
+        return FaultStudyResult(
+            spec=spec,
+            fault_current_pu=I_fault,
+            buses=results,
+        )
+
+from maths.power_flow import PowerFlow  # ajusta o caminho caso esteja diferente
+
+
+
+def run_three_phase_fault_from_powerflow(
+    pf: PowerFlow,
+    bus_id: str,
+    z_fault_pu: complex = 0+0j,
+    description: str | None = None,
+) -> FaultStudyResult:
+    """
+    Executa um estudo de falta trifásica (3φ) em qualquer sistema
+    representado por um PowerFlow JÁ RESOLVIDO (pf.solve()).
+
+    - pf: objeto PowerFlow com o sistema atual (o que o usuário montou)
+    - bus_id: id da barra onde ocorre a falta (string)
+    - z_fault_pu: impedância da falta em pu (0 -> falta sólida)
+    - description: texto opcional descritivo
+    """
+    if description is None:
+        description = f"Falta 3φ na barra {bus_id}"
+
+    # Extrai dados de pré-falta e Ybus do PowerFlow
+    ybus = pf.get_ybus_numpy()
+    pre_v = pf.get_bus_voltages_complex_pu()
+    bus_index = pf.get_bus_index_dict()
+
+    solver = ShortCircuitSolver(ybus, pre_v, bus_index)
+
+    spec = FaultSpec(
+        bus_id=bus_id,
+        fault_type=FaultType.THREE_PHASE,
+        z_fault_pu=z_fault_pu,
+        description=description,
+    )
+
+    return solver.three_phase_fault(spec)
+
+
+#teste
+
+if __name__ == "__main__":
+    # - B1: barra slack, 1∠0 pu
+    # - B2: barra de carga, 0.98∠-2° (pré-falta)
+    #
+    # Ybus fictícia só pra testar (2x2):
+    Y = np.array([
+        [10 - 30j, -10 + 30j],
+        [-10 + 30j, 10 - 30j],
+    ], dtype=complex)
+
+    # Tensões pré-falta (em pu)
+    pre_v = {
+        "B1": 1.0 + 0.0j,
+        "B2": 0.98 * np.exp(-1j * np.deg2rad(2.0)),  # módulo 0.98, ângulo -2°
+    }
+
+    bus_index = {
+        "B1": 0,
+        "B2": 1,
+    }
+
+    solver = ShortCircuitSolver(Y, pre_v, bus_index)
+
+    # falta trifásica na barra B2, Zf = 0
+    result = solver.three_phase_fault("B2", z_fault_pu=0 + 0j)
+
+    print("Barra em falta:", result.fault_bus_id)
+    print("Corrente de falta I_f (pu):", result.I_fault)
+    print("Tensões pós-falta:")
+    for bus_id, v in result.V_post.items():
+        mag = np.abs(v)
+        ang = np.rad2deg(np.angle(v))
+        print(f"  {bus_id}: {mag:.4f} pu ∠ {ang:.2f}°")

--- a/src/models/faults.py
+++ b/src/models/faults.py
@@ -1,0 +1,57 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict
+
+
+class FaultType(Enum):
+    """
+    Tipos de falta que vamos suportar.
+
+    Por enquanto vamos usar só THREE_PHASE (3φ),
+    mas já deixamos as outras preparadas para o futuro.
+    """
+    THREE_PHASE = "3φ"   # falta trifásica simétrica
+    SLG = "SLG"          # falta monofásica terra
+    LL = "LL"            # falta fase-fase
+    DLG = "DLG"          # falta dupla-fase terra
+
+
+@dataclass
+class FaultSpec:
+    """
+    Especificação de uma falta (entrada do estudo).
+
+    Exemplo:
+        FaultSpec(bus_id="B5", fault_type=FaultType.THREE_PHASE)
+    """
+    bus_id: str
+    fault_type: FaultType
+    z_fault_pu: complex = 0+0j
+    description: str = ""
+
+
+@dataclass
+class FaultResultBasic:
+    """
+    Resultado básico em uma barra para um estudo de falta.
+
+    v_pu: tensão em pu (seq. positiva / fase equivalente)
+    i_pu: corrente em pu (seq. positiva / fase equivalente)
+    """
+    bus_id: str
+    v_pu: complex
+    i_pu: complex
+
+
+@dataclass
+class FaultStudyResult:
+    """
+    Resultado de um estudo de falta (por enquanto, 3φ):
+
+    - spec: dados da falta (onde, tipo, Zf)
+    - fault_current_pu: corrente de falta na barra em falta (pu)
+    - buses: resultados por barra (tensão e corrente “local” simplificada)
+    """
+    spec: FaultSpec
+    fault_current_pu: complex
+    buses: Dict[str, FaultResultBasic]

--- a/src/test_fault_from_powerflow.py
+++ b/src/test_fault_from_powerflow.py
@@ -1,0 +1,47 @@
+import numpy as np
+from pathlib import Path
+
+from storage.storage import StorageFacade
+from maths.short_circuit import run_three_phase_fault_from_powerflow
+from models.bus import BusType
+
+
+def main():
+    project_root = Path(__file__).resolve().parent.parent
+    ieee_path = project_root / "assets" / "ieee_examples" / "ieee14cdf.txt"
+
+    print(f"Carregando caso IEEE de: {ieee_path}")
+
+    pf = StorageFacade.read_ieee_file(str(ieee_path))
+
+    pf.solve()
+
+    # Escolhe uma barra não-SLACK só pra testar
+    candidate_buses = [b.id for b in pf.buses.values() if b.type != BusType.SLACK]
+    fault_bus_id = candidate_buses[0]
+
+    result = run_three_phase_fault_from_powerflow(
+        pf,
+        fault_bus_id,
+        z_fault_pu=0+0j,
+        description=f"Falta 3φ sólida na barra {fault_bus_id}",
+    )
+
+    print()
+    print(f"Estudo: {result.spec.description}")
+    print(f"Corrente de falta na barra {fault_bus_id}:")
+    If = result.fault_current_pu
+    If_mag = np.abs(If)
+    If_ang = np.rad2deg(np.angle(If))
+    print(f"  |If| = {If_mag:.4f} pu, ∠If = {If_ang:.2f}°")
+
+    print("\nResultados por barra (pós-falta):")
+    for bus_id, r in result.buses.items():
+        v_mag = np.abs(r.v_pu)
+        v_ang = np.rad2deg(np.angle(r.v_pu))
+        i_mag = np.abs(r.i_pu)
+        print(f"  {bus_id}: |V|={v_mag:.4f} pu, ∠V={v_ang:6.2f}°, |I|={i_mag:.4f} pu")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/test_three_phase_fault.py
+++ b/src/test_three_phase_fault.py
@@ -1,0 +1,108 @@
+from typing import Dict
+import numpy as np
+
+from models.faults import FaultSpec, FaultType, FaultResultBasic
+
+
+class ShortCircuitSolver:
+    """
+    Resolve falta trifásica (simétrica) usando apenas a rede de sequência positiva.
+    """
+
+    def __init__(self, ybus: np.ndarray, pre_fault_voltages: Dict[str, complex], bus_index: Dict[str, int]):
+        """
+        :param ybus: matriz Ybus (sequência positiva), NxN, como numpy.array de complexos
+        :param pre_fault_voltages: tensões pré-falta em pu, ex: {"B1": 1+0j, "B2": 0.98-0.02j, ...}
+        :param bus_index: mapeia id da barra -> índice da matriz, ex: {"B1": 0, "B2": 1, ...}
+        """
+        self.ybus = ybus
+        self.pre_v = pre_fault_voltages
+        self.bus_index = bus_index
+
+        # Calcula Zbus = Ybus^(-1)
+        self.zbus = np.linalg.inv(self.ybus)
+
+    def three_phase_fault(self, spec: FaultSpec) -> Dict[str, FaultResultBasic]:
+        """
+        Calcula falta trifásica (simétrica) em uma barra.
+
+        Usa apenas a rede de sequência positiva.
+        """
+        if spec.fault_type != FaultType.THREE_PHASE:
+            raise ValueError("three_phase_fault só aceita FaultType.THREE_PHASE")
+
+        fault_bus_id = spec.bus_id
+        z_fault_pu = spec.z_fault_pu
+
+        # índice da barra de falta na matriz
+        k = self.bus_index[fault_bus_id]
+
+        # tensão pré-falta na barra de falta
+        V_pref = self.pre_v[fault_bus_id]
+
+        # impedância de Thevenin vista da barra de falta
+        Z_th = self.zbus[k, k]
+
+        # corrente de falta
+        I_fault = V_pref / (Z_th + z_fault_pu)
+
+        # resultado por barra
+        results: Dict[str, FaultResultBasic] = {}
+
+        for bus_id, i in self.bus_index.items():
+            Zik = self.zbus[i, k]
+            V_post = self.pre_v[bus_id] - Zik * I_fault
+
+            # por enquanto, corrente não nula só na barra em falta
+            I_bus = I_fault if bus_id == fault_bus_id else 0+0j
+
+            results[bus_id] = FaultResultBasic(
+                bus_id=bus_id,
+                v_pu=V_post,
+                i_pu=I_bus,
+            )
+
+        return results
+
+
+# Teste isolado.
+
+if __name__ == "__main__":
+    # Exemplo de 2 barras inventado:
+    # - B1: barra slack, 1∠0 pu
+    # - B2: barra de carga, 0.98∠-2° (pré-falta)
+
+    Y = np.array([
+        [10 - 30j, -10 + 30j],
+        [-10 + 30j, 10 - 30j],
+    ], dtype=complex)
+
+    pre_v = {
+        "B1": 1.0 + 0.0j,
+        "B2": 0.98 * np.exp(-1j * np.deg2rad(2.0)),  # módulo 0.98, ângulo -2°
+    }
+
+    bus_index = {
+        "B1": 0,
+        "B2": 1,
+    }
+
+    solver = ShortCircuitSolver(Y, pre_v, bus_index)
+
+    # Monta o FaultSpec da falta trifásica em B2
+    spec = FaultSpec(
+        bus_id="B2",
+        fault_type=FaultType.THREE_PHASE,
+        z_fault_pu=0+0j,
+        description="Falta 3φ sólida na barra B2",
+    )
+
+    results = solver.three_phase_fault(spec)
+
+    print(f"Estudo: {spec.description}")
+    print("Resultados por barra:")
+    for bus_id, r in results.items():
+        v_mag = np.abs(r.v_pu)
+        v_ang = np.rad2deg(np.angle(r.v_pu))
+        i_mag = np.abs(r.i_pu)
+        print(f"  {bus_id}: |V|={v_mag:.4f} pu, ∠V={v_ang:6.2f}°, |I|={i_mag:.4f} pu")

--- a/src/view/bus_widget.py
+++ b/src/view/bus_widget.py
@@ -32,6 +32,12 @@ class BusWidget(QGraphicsRectItem):
             self.bus = node
             self.label.setText(self.__label)
 
+    def mouseDoubleClickEvent(self, event):
+        # Duplo clique na barra -> estudo de falta trifásica nesta barra
+        SimulatorController.instance().runThreePhaseFaultOnBus(self.bus.id)
+        super().mouseDoubleClickEvent(event)
+
+
     @property
     def __label(self) -> str:
         bus: Bus = self.bus


### PR DESCRIPTION
- Implementa cálculo de falta trifásica (3φ) usando Ybus + tensões pré-falta
- Cria modelos FaultSpec, FaultResultBasic e FaultStudyResult
- Adiciona função run_three_phase_fault_from_powerflow
- Integra com a interface: duplo clique na barra executa falta 3φ e mostra |If| em pu